### PR TITLE
result_formatters/plain.rs: fix off by 1 in header

### DIFF
--- a/src/result_formatters/plain.rs
+++ b/src/result_formatters/plain.rs
@@ -42,7 +42,7 @@ pub fn print_plain(config: &Config, result: &AnalyzerResult) {
         "",
         "",
         indent = options.key_column_width,
-        indenx = options.count_column_width - 9,
+        indenx = options.count_column_width - 10,
     );
 
     print_tree(


### PR DESCRIPTION
The length of "Keys Count" is 10, not 9. We can see in the readme.md that the first digit is not properly aligned beloy the Memory Usage column