### PR TITLE
fix: rename misspelled format variable indenx to count_indent

### DIFF
--- a/src/result_formatters/plain.rs
+++ b/src/result_formatters/plain.rs
@@ -38,11 +38,11 @@ pub fn print_plain(config: &Config, result: &AnalyzerResult) {
 
     println!("Took {:.2?}", result.took);
     println!(
-        "{:indent$}Keys Count{:indenx$}Memory Usage",
+        "{:indent$}Keys Count{:count_indent$}Memory Usage",
         "",
         "",
         indent = options.key_column_width,
-        indenx = options.count_column_width - 10,
+        count_indent = options.count_column_width - 10,
     );
 
     print_tree(


### PR DESCRIPTION
The format string in `plain.rs` uses a variable named `indenx` — a typo of `indent`. Since `indent` is already used for the key column width, this renames the count-column variable to `count_indent` to fix the typo while preserving the distinct values.

No behavioral change — the variable holds the same value, just has a correct name now.